### PR TITLE
Bump money gem to 6.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@ source :rubygems
 # Specify gem dependencies in money_column.gemspec
 gemspec
 
-gem 'activesupport', '2.3.14'
+gem 'activesupport', '3.2.18'
+gem 'monetize', '0.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,30 @@
 PATH
   remote: .
   specs:
-    money_column (0.2.1)
-      activesupport (>= 2.3.14)
-      money (~> 2.2.0)
+    money_column (0.2.3)
+      activesupport (= 3.2.18)
+      monetize (= 0.3.0)
+      money (= 6.1.1)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (2.3.14)
+    activesupport (3.2.18)
+      i18n (~> 0.6, >= 0.6.4)
+      multi_json (~> 1.0)
     diff-lcs (1.1.3)
     growl (1.0.3)
     guard (0.8.8)
       thor (~> 0.14.6)
     guard-rspec (0.5.8)
       guard (>= 0.8.4)
-    money (2.2.0)
+    i18n (0.6.9)
+    monetize (0.3.0)
+      money (~> 6.1.0.beta1)
+    money (6.1.1)
+      i18n (~> 0.6.4)
+    multi_json (1.10.1)
     rake (0.9.2.2)
-    rb-fsevent (0.4.3.1)
     rspec (2.7.0)
       rspec-core (~> 2.7.0)
       rspec-expectations (~> 2.7.0)
@@ -32,10 +39,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (= 2.3.14)
+  activesupport (= 3.2.18)
   growl (~> 1.0.3)
   guard-rspec (~> 0.5.0)
+  monetize (= 0.3.0)
   money_column!
   rake (~> 0.9.2)
-  rb-fsevent (~> 0.4.2)
   rspec (~> 2.7.0)

--- a/lib/money_column.rb
+++ b/lib/money_column.rb
@@ -1,7 +1,8 @@
 require 'rubygems'
 require 'money'
-require 'active_support'
+require 'active_support/core_ext/hash'
 require 'money_column/stores_money'
+require 'monetize'
 
 # FREEDOM PATCH - Since a money column might validly return nil, 
 # let's allow +format+ to be called on nil and just return nil as a string

--- a/lib/money_column/stores_money.rb
+++ b/lib/money_column/stores_money.rb
@@ -22,7 +22,7 @@ module MoneyColumn
             if cents.blank?
               nil
             else
-              my_currency = self.respond_to?(:currency) ? currency : ::Money.default_currency
+              my_currency = self.respond_to?(:currency) && !self.currency.nil? ? currency : ::Money.default_currency
               Money.new(cents, my_currency)
             end
           end

--- a/lib/money_column/version.rb
+++ b/lib/money_column/version.rb
@@ -1,3 +1,3 @@
 module MoneyColumn
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/money_column.gemspec
+++ b/money_column.gemspec
@@ -19,8 +19,9 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib]
 
   # Runtime Dependencies
-  s.add_runtime_dependency('activesupport', '>= 2.3.14')
-  s.add_runtime_dependency('money', '>= 2.2.0')
+  s.add_runtime_dependency('activesupport', '3.2.18')
+  s.add_runtime_dependency('money', '6.1.1')
+  s.add_runtime_dependency('monetize', '0.3.0')
 
   # Development Dependencies
   s.add_development_dependency('rake', '~> 0.9.2')


### PR DESCRIPTION
- Bumps `money` to `6.1.1`
- Bumps `activesupport` to `3.2.18`
- Adds `monetize 0.3.0`
- Bumps gem version to `0.2.3`
