### PR TITLE
Remove the restriction on ActiveSupport version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,3 @@ source 'https://rubygems.org'
 
 # Specify gem dependencies in money_column.gemspec
 gemspec
-
-gem 'activesupport', '~> 4.0.13'
-gem 'monetize', '0.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     money_column (0.2.4)
-      activesupport
+      activesupport (< 6)
       monetize (= 1.3.0)
       money (~> 6.5)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,22 +2,22 @@ PATH
   remote: .
   specs:
     money_column (0.2.4)
-      activesupport (~> 4.0)
-      monetize (= 0.3.0)
-      money (= 6.1.1)
+      activesupport
+      monetize (= 1.3.0)
+      money (~> 6.5)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.0.13)
-      i18n (~> 0.6, >= 0.6.9)
-      minitest (~> 4.2)
-      multi_json (~> 1.3)
-      thread_safe (~> 0.1)
-      tzinfo (~> 0.3.37)
+    activesupport (5.2.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     celluloid (0.15.2)
       timers (~> 1.1.0)
     coderay (1.1.0)
+    concurrent-ruby (1.1.5)
     diff-lcs (1.2.5)
     ffi (1.9.3)
     formatador (0.2.5)
@@ -31,19 +31,18 @@ GEM
     guard-rspec (4.2.10)
       guard (~> 2.1)
       rspec (>= 2.14, < 4.0)
-    i18n (0.6.11)
+    i18n (0.7.0)
     listen (2.7.9)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     lumberjack (1.0.9)
     method_source (0.8.2)
-    minitest (4.7.5)
-    monetize (0.3.0)
-      money (~> 6.1.0.beta1)
-    money (6.1.1)
-      i18n (~> 0.6.4)
-    multi_json (1.11.2)
+    minitest (5.11.3)
+    monetize (1.3.0)
+      money (~> 6.5.0)
+    money (6.5.1)
+      i18n (>= 0.6.4, <= 0.7.0)
     pry (0.10.0)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -66,22 +65,21 @@ GEM
     rspec-support (3.0.2)
     slop (3.5.0)
     thor (0.19.1)
-    thread_safe (0.3.5)
+    thread_safe (0.3.6)
     timers (1.1.0)
-    tzinfo (0.3.46)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (~> 4.0.13)
   growl (~> 1.0.3)
   guard-rspec (~> 4.2.10)
-  monetize (= 0.3.0)
   money_column!
   rake (~> 10.5.0)
   rb-fsevent (~> 0.9.4)
   rspec (~> 3.0.0)
 
 BUNDLED WITH
-   1.11.2
+   1.17.3

--- a/money_column.gemspec
+++ b/money_column.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib]
 
   # Runtime Dependencies
-  s.add_runtime_dependency('activesupport')
+  s.add_runtime_dependency('activesupport', '< 6')
   s.add_runtime_dependency('money', '~> 6.5')
   s.add_runtime_dependency('monetize', '1.3.0')
 

--- a/money_column.gemspec
+++ b/money_column.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib]
 
   # Runtime Dependencies
-  s.add_runtime_dependency('activesupport', '~> 4.0')
+  s.add_runtime_dependency('activesupport')
   s.add_runtime_dependency('money', '~> 6.5')
   s.add_runtime_dependency('monetize', '1.3.0')
 


### PR DESCRIPTION
The current version of activesupport the money_column is restricted to has an open CVE, and there is no reason to be so restrictive with the versioning. This has been tested on the latest version of ActiveSupport with no issues and can be reverified if we need to add support for ActiveSupport 6 when the time comes.