### PR TITLE
Removes dependency on `active_support`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,3 @@ source 'https://rubygems.org'
 
 # Specify gem dependencies in money_column.gemspec
 gemspec
-
-gem 'activesupport', '~> 4.0.13'
-gem 'monetize', '0.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,19 +2,13 @@ PATH
   remote: .
   specs:
     money_column (0.2.4)
-      activesupport (~> 4.0)
-      monetize (= 0.3.0)
-      money (= 6.1.1)
+      i18n (>= 0.7.0)
+      monetize (= 1.3.0)
+      money (~> 6.5)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.0.13)
-      i18n (~> 0.6, >= 0.6.9)
-      minitest (~> 4.2)
-      multi_json (~> 1.3)
-      thread_safe (~> 0.1)
-      tzinfo (~> 0.3.37)
     celluloid (0.15.2)
       timers (~> 1.1.0)
     coderay (1.1.0)
@@ -31,19 +25,17 @@ GEM
     guard-rspec (4.2.10)
       guard (~> 2.1)
       rspec (>= 2.14, < 4.0)
-    i18n (0.6.11)
+    i18n (0.7.0)
     listen (2.7.9)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     lumberjack (1.0.9)
     method_source (0.8.2)
-    minitest (4.7.5)
-    monetize (0.3.0)
-      money (~> 6.1.0.beta1)
-    money (6.1.1)
-      i18n (~> 0.6.4)
-    multi_json (1.11.2)
+    monetize (1.3.0)
+      money (~> 6.5.0)
+    money (6.5.1)
+      i18n (>= 0.6.4, <= 0.7.0)
     pry (0.10.0)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -66,22 +58,18 @@ GEM
     rspec-support (3.0.2)
     slop (3.5.0)
     thor (0.19.1)
-    thread_safe (0.3.5)
     timers (1.1.0)
-    tzinfo (0.3.46)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (~> 4.0.13)
   growl (~> 1.0.3)
   guard-rspec (~> 4.2.10)
-  monetize (= 0.3.0)
   money_column!
   rake (~> 10.5.0)
   rb-fsevent (~> 0.9.4)
   rspec (~> 3.0.0)
 
 BUNDLED WITH
-   1.11.2
+   1.17.3

--- a/lib/money_column.rb
+++ b/lib/money_column.rb
@@ -1,6 +1,5 @@
 require 'rubygems'
 require 'money'
-require 'active_support/core_ext/hash'
 require 'money_column/stores_money'
 require 'monetize'
 

--- a/lib/money_column/stores_money.rb
+++ b/lib/money_column/stores_money.rb
@@ -6,10 +6,11 @@ module MoneyColumn
 
     module ClassMethods
       def stores_money(money_name, options = {})
-        options.reverse_merge!({
-          :cents_attribute => "#{money_name}_in_cents",
-          :allow_nil => true
-        })
+        options =
+          {
+            :cents_attribute => "#{money_name}_in_cents",
+            :allow_nil => true
+          }.merge(options)
 
         class_eval <<-EOV
           def #{money_name}
@@ -19,7 +20,7 @@ module MoneyColumn
               cents ||= 0
             end
 
-            if cents.blank?
+            if cents.to_s.empty?
               nil
             else
               Money.new(cents, money_currency)
@@ -27,7 +28,7 @@ module MoneyColumn
           end
 
           def #{money_name}=(amount)
-            self.#{options[:cents_attribute]} = if amount.blank?
+            self.#{options[:cents_attribute]} = if amount.to_s.empty?
               nil
             else
               amount.to_money(money_currency).cents

--- a/money_column.gemspec
+++ b/money_column.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib]
 
   # Runtime Dependencies
-  s.add_runtime_dependency('activesupport', '~> 4.0')
   s.add_runtime_dependency('money', '~> 6.5')
   s.add_runtime_dependency('monetize', '1.3.0')
+  s.add_runtime_dependency('i18n', '>= 0.7.0')
 
   # Development Dependencies
   s.add_development_dependency('rake', '~> 10.5.0')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,5 @@ RSpec.configure do |config|
   config.alias_example_to :fit, focused: true
   config.run_all_when_everything_filtered = true
 end
+
+I18n.config.available_locales = :en


### PR DESCRIPTION
This required a couple of different approaches. First, the `.blank?`
checks have been converted to a `.to_s.empty?` check. This will cover
everything other than the case of `false`. Second, the reverse_merge was
switched around to work the same way without bringing in the entire
behemoth that is activesupport.

Lastly, I added a runtime dependency for a specific version of i18n and
also setup the available locales per the update in the spec helper.