### PR TITLE
Removes strict versioning from monetize and money gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,8 @@ PATH
   remote: .
   specs:
     money_column (0.2.4)
-      i18n (>= 0.7.0)
-      monetize (= 1.3.0)
-      money (~> 6.5)
+      monetize
+      money
 
 GEM
   remote: https://rubygems.org/
@@ -32,10 +31,10 @@ GEM
       rb-inotify (>= 0.9)
     lumberjack (1.0.9)
     method_source (0.8.2)
-    monetize (1.3.0)
-      money (~> 6.5.0)
-    money (6.5.1)
-      i18n (>= 0.6.4, <= 0.7.0)
+    monetize (1.9.2)
+      money (~> 6.12)
+    money (6.13.4)
+      i18n (>= 0.6.4, <= 2)
     pry (0.10.0)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -66,6 +65,7 @@ PLATFORMS
 DEPENDENCIES
   growl (~> 1.0.3)
   guard-rspec (~> 4.2.10)
+  i18n (>= 0.7.0)
   money_column!
   rake (~> 10.5.0)
   rb-fsevent (~> 0.9.4)

--- a/money_column.gemspec
+++ b/money_column.gemspec
@@ -19,9 +19,8 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib]
 
   # Runtime Dependencies
-  s.add_runtime_dependency('money', '~> 6.5')
-  s.add_runtime_dependency('monetize', '1.3.0')
-  s.add_runtime_dependency('i18n', '>= 0.7.0')
+  s.add_runtime_dependency('money')
+  s.add_runtime_dependency('monetize')
 
   # Development Dependencies
   s.add_development_dependency('rake', '~> 10.5.0')
@@ -29,4 +28,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('guard-rspec', '~> 4.2.10')
   s.add_development_dependency('growl', '~> 1.0.3')
   s.add_development_dependency('rb-fsevent', '~> 0.9.4')
+  s.add_development_dependency('i18n', '>= 0.7.0')
 end


### PR DESCRIPTION
Allow apps using money_column to determine the version of money and
monetize instead of strict versioning.

Moves i18n to a development dependency because it is only used in tests.